### PR TITLE
Update hr_training.md with NICE Framework data

### DIFF
--- a/hr_training.md
+++ b/hr_training.md
@@ -37,6 +37,16 @@ As per what is explained on the [management page](https://github.com/cyb3rxp/awe
 
 They can be FTE or outsourced, it will depend on your needs and constraints. My recommendations are explained in the RACI template that I propose.
 
+## NICE Framework
+
+NIST 800-181 National Initiative for Cybersecurity Education Framework (NICE Framework) has done work to standardise job roles in the area. These roles have standardised descriptions with a list of Tasks that the role typically does, as well as Tasks, Knowledge and Abiltiy to undertake that role. It is mainly focused on US Government, and includes some roles which are typical for the defence or intelligence sector. 
+
+https://niccs.cisa.gov/workforce-development/nice-framework
+
+These roles can be difficult to understand intiially, but it is simple to map them through to your existing roles (for example, *Cyber Defence Analyst* = SOC Analyst, *Cyber Defence Infrastructure Support* = SOC Detection Engineer). Alternatively you can readily build custom job roles utilising the Tasks, Knowledge, Abilities, and Skills listed in the framework. 
+
+There is a reference spreadsheet that NIST released that can assist in building custom roles:
+https://www.nist.gov/document/supplementnicespecialtyareasandworkroleksasandtasksxlsx
 
 # Recommended SOC trainings
 


### PR DESCRIPTION
Hello,

I'm proposing a small addition to the hr_training document where I'm including reference to the NIST 800-181 package of work. This SP presents standardised Knowledge, Skills, Abilities which cybersecurity professionals should have, as well as Tasks they typically complete.

Someone building a SOC can utilise this Framework to design their own job roles utilising standardised languages. I know when I've had to fight for extra resources in the past, being able to refer to a standard has made my life a lot easier when getting things across the line with management.

https://www.nist.gov/itl/applied-cybersecurity/nice/nice-framework-resource-center/getting-started