### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,5 +1,8 @@
 name: Link Checker
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/cyb3rxp/awesome-soc/security/code-scanning/4](https://github.com/cyb3rxp/awesome-soc/security/code-scanning/4)

In general, the fix is to explicitly declare a minimal `permissions:` block for the workflow or the specific job so that the `GITHUB_TOKEN` is limited to the least privileges required. For a link-checking job that only needs to read repository contents, `contents: read` is sufficient in most cases.

The best targeted fix here is to add a `permissions:` block at the workflow root (top level, alongside `name` and `on`), so it applies to all jobs in this workflow. We should set `contents: read`, which is the standard minimal starting point recommended by GitHub and CodeQL, and which is adequate for `actions/checkout` to read the repository. No behavior of the existing steps changes: the job will still be able to check out the repo and run the Lychee link checker, but any write capabilities of the token will be removed.

Concretely, in `.github/workflows/link-check.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `name:` and `on:` keys (e.g., after line 2). No additional imports, methods, or other definitions are needed; this is purely a workflow configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
