### PR TITLE
Add CISA KEV Deadline Planner

### DIFF
--- a/watch.md
+++ b/watch.md
@@ -24,6 +24,7 @@ This page deals with IT/cybersecurity watch (recommended sources and tools)
     
 * Known exploited vulnerabilities +0days: 
   * [CISA catalog](https://www.cisa.gov/known-exploited-vulnerabilities-catalog)
+  * [CISA KEV Deadline Planner](https://kev-deadline-planner.vercel.app/) - Unofficial browser worksheet to match pasted CVEs against a bundled CISA KEV snapshot and export CSV/Markdown/ICS planning queues.
   * [Top 0days "in the wild"](https://docs.google.com/spreadsheets/d/1lkNJ0uQwbeC1ZTRrxdtuPLCIl7mlUreoKfSIgajnSyY/edit?gid=1331951416#gid=1331951416)
   * [ZeroDayClocl](https://zerodayclock.com/)
 * LinkedIn / Twitter:


### PR DESCRIPTION
Adds an unofficial browser worksheet for matching pasted CVEs against a bundled CISA KEV snapshot and exporting CSV/Markdown/ICS planning queues.\n\nFit: the existing IT/security watch section already lists known exploited vulnerability and 0-day resources, including the CISA KEV catalog.\n\nDisclosure: I maintain this free/open-source tool.