### PR TITLE
Add CyStack Stealer Fingerprints to Threat Intelligence sources

### DIFF
--- a/threat_intelligence.md
+++ b/threat_intelligence.md
@@ -150,6 +150,7 @@ Here is [another example](https://www.infinigate.com/fr/vendors/sekoia/) of an a
      * [Maltiverse](https://lumu.io/maltiverse/)
      * [StalkPhish](https://www.stalkphish.io/)
      * CIRCL [GCVE Vulnerability Lookup](https://vulnerability.circl.lu/)
+     * CyStack, [Stealer Fingerprints](https://github.com/cystack/stealer-fingerprints) (infostealer log fingerprints maintained from CyStack's intel pipeline);
   * To go further, some lists of feeds that could be of interest:
     * [Covert.io list](http://www.covert.io/threat-intelligence/);
     * [Bert JanP](https://github.com/Bert-JanP/Open-Source-Threat-Intel-Feeds/tree/main);


### PR DESCRIPTION
Adds CyStack Stealer Fingerprints to the Threat Intelligence sources (community feeds).

Apache-2.0 catalog of infostealer log fingerprints maintained from CyStack's own stealer log intel pipeline. Covers 30+ families (RedLine, Vidar, Lumma, StealC and others) with banner strings, field signatures, YARA rules, and sanitized samples. Refreshed as new families and variants are observed in production telemetry.

Repo: https://github.com/cystack/stealer-fingerprints