### PR TITLE
Add defend.network to Threat Intelligence sources

### DIFF
--- a/threat_intelligence.md
+++ b/threat_intelligence.md
@@ -151,6 +151,7 @@ Here is [another example](https://www.infinigate.com/fr/vendors/sekoia/) of an a
      * [StalkPhish](https://www.stalkphish.io/)
      * CIRCL [GCVE Vulnerability Lookup](https://vulnerability.circl.lu/)
      * CyStack, [Stealer Fingerprints](https://github.com/cystack/stealer-fingerprints) (infostealer log fingerprints maintained from CyStack's intel pipeline);
+     * [defend.network](https://defend.network/feed.xml) (free daily cyber threat briefings and weekly vulnerability reports, every CVE verified against NVD and CISA KEV; RSS feed);
   * To go further, some lists of feeds that could be of interest:
     * [Covert.io list](http://www.covert.io/threat-intelligence/);
     * [Bert JanP](https://github.com/Bert-JanP/Open-Source-Threat-Intel-Feeds/tree/main);


### PR DESCRIPTION
Adds [defend.network](https://defend.network) to the community sources in `threat_intelligence.md`.

defend.network is a free, no-login source publishing daily cyber threat briefings and weekly vulnerability reports, with every CVE cross-checked against NVD and the CISA KEV catalog. Content is structured by threat type, industry, and severity, with remediation guidance. The RSS feed is at https://defend.network/feed.xml.

Thanks for maintaining Awesome SOC!