### PR TITLE
Add threat intelligence resource: AdversaryGraph

### DIFF
--- a/threat_intelligence.md
+++ b/threat_intelligence.md
@@ -82,6 +82,7 @@ Here is [an overview](https://erdalozkaya.com/cyber-threat-intelligence/) of a g
 ## TIP choice 
 Here are my recommendations:
 * for community ones: [MISP](https://www.misp-project.org/), [OpenCTI](https://www.filigran.io/en/products/opencti/);
+* for CTI-to-detection analysis workflow: [AdversaryGraph](https://github.com/anpa1200/adversarygraph) (ATT&CK/ATLAS mapping, IOC enrichment, TTP comparison, and analyst handoff artifacts);
 * for paid ones: [Sekoia.io](https://www.sekoia.io/fr/produire-et-personnaliser-votre-propre-intelligence/), [ThreatQuotient](https://www.threatq.com/).
 
 ## Common TIP integrations (dataflow)


### PR DESCRIPTION
Adds AdversaryGraph to the dedicated threat intelligence page under CTI-to-detection analysis workflow.

AdversaryGraph supports ATT&CK/ATLAS mapping, IOC enrichment, TTP comparison, and analyst handoff artifacts for SOC teams.

Validation: git diff --check.