### PR TITLE
Add detection engineering resource: Clankerusecase

### DIFF
--- a/detection_engineering.md
+++ b/detection_engineering.md
@@ -28,6 +28,7 @@ This page deals with SOC detection engineering and management (detection use cas
 * CyberSecurityForMe, [Microsoft Copilot Security vulnerabilities and countermeasures](https://cybersecurityforme.com/copilot-security-vulnerabilities-and-safety-measures-for-enterprises/)
 * My [recommended list of sources](https://github.com/cyb3rxp/awesome-soc/blob/main/watch.md)
 ## SIEM rules publications
+  * [Clankerusecase (threat-led detection library)](https://clankerusecase.com/) — free, ATT&CK-mapped detections in Defender/Sentinel KQL, Sigma, Splunk SPL, Datadog, Falcon and CloudWatch, generated from public threat intel.
   * [Sigma HQ (detection rules)](https://github.com/SigmaHQ/sigma/tree/master/rules) 
   * Splunk [Detections (free detection rules for Splunk)](https://research.splunk.com/detections/)
   * Splunk [Stories for Office 365](https://research.splunk.com/stories/office_365_collection_techniques/)


### PR DESCRIPTION
Adds Clankerusecase (https://clankerusecase.com), an open-source, MIT-licensed detection library: 7,800+ MITRE ATT&CK-mapped detections generated from public threat-intel reporting, each available in Defender KQL, Sentinel KQL, Sigma, Splunk SPL, Datadog, CrowdStrike Falcon LogScale, and AWS CloudWatch. All queries are schema/syntax-validated before publish. Also ships machine-readable IOC feeds (CSV/JSON/STIX 2.1/RSS) and pySigma-parseable Sigma + Elastic rule packs.

Repo: https://github.com/Virtualhaggis/usecaseintel