### PR TITLE
Add Cynative to cloud tools list

### DIFF
--- a/mission-critical-means.md
+++ b/mission-critical-means.md
@@ -90,6 +90,7 @@ The provided recommendations are based on experience and search.
        * For GWS specifically:
          * [ALFA](https://github.com/invictus-ir/ALFA)
        * For Azure / GCP / AWS:
+         * [Cynative](https://github.com/cynative/cynative)
          * [ScootSuite](https://github.com/nccgroup/ScoutSuite)
 * **On-demand volatile data collection tool**:
   * My recommendations: [FastIR](https://github.com/OWNsecurity/fastir_artifacts), [VARC](https://github.com/cado-security/varc), [FireEye Redline](https://fireeye.market/apps/211364), [DFIR-ORC](https://github.com/dfir-orc);


### PR DESCRIPTION
Added Cynative, Read-only deep research for AWS, GCP, Azure, K8s, GitHub & GitLab. Open-source BYOM CLI agent built with Go.

Full disclosure: I maintain Cynative.