### PR TITLE
Add Control Assurance Lab to detection engineering tools

### DIFF
--- a/detection_engineering.md
+++ b/detection_engineering.md
@@ -422,6 +422,7 @@ See [threat intel page](https://github.com/cyb3rxp/awesome-soc/blob/main/threat_
 The idea here is to follow the 'as-code' approach, wherever possible, with a central repository as a versioning system and source of truth. This, in order to achieve automation, quality controls, resilience (restore previous version in case something breaks), R&D with PDCA, etc. For instance, based on experience, this is applicable to SIEM rules, SOA playbooks, SOP, etc. 
 
 ## Required tools
+* [Control Assurance Lab](https://github.com/gyubin02/control-assurance-lab) - Runs reproducible matched-intervention tests to determine whether a target security control worked or a downstream safeguard merely hid its failure.
 * My recommendation: [GitLab](https://about.gitlab.com/) (or equivalent)
 * KQLab [Self-hosted KQL/SPL/ELK query manager for SOC teams](https://github.com/vinsk0h/KQLab)
 


### PR DESCRIPTION
## What changed

Adds Control Assurance Lab to the detection engineering `Everything-as-code (DevSecOps)` tool list. I maintain the linked project.

## Why it fits

The project is a reference implementation for testing SOC control chains with matched synthetic executions. It records whether the intended control acted and whether a downstream safeguard merely masked a failure, which is useful when validating detection and delivery paths as code.

The project is currently alpha, its included cases are synthetic, and its output is technical evidence rather than compliance certification. The repository includes local test instructions and operator documentation.

## Validation

- Confirmed the resource was not already listed.
- Kept the change to one line in the existing required-tools section.
- Verified the target URL returns successfully.
- Ran `git diff --check`.
