### PR TITLE
Add ThreatCluster to threat intelligence sources

### DIFF
--- a/threat_intelligence.md
+++ b/threat_intelligence.md
@@ -131,6 +131,7 @@ Here is [another example](https://www.infinigate.com/fr/vendors/sekoia/) of an a
      * [Intrinsec IOC](https://github.com/Intrinsec/IOCs);
      * [Malware-IOC](https://github.com/executemalware/Malware-IOCs);
      * [OpenPhish](https://openphish.com/feed.txt);
+     * [ThreatCluster IOC feed](https://threatcluster.io/iocs);
      * [Bazaar](https://bazaar.abuse.ch/export/csv/recent/);
      * [C2IntelFeeds](https://raw.githubusercontent.com/drb-ra/C2IntelFeeds/master/feeds/IPC2s-30day.csv);
      * [Circle's MISP feed](https://www.circl.lu/doc/misp/feed-osint/);


### PR DESCRIPTION
Free resource, no account needed for the cluster and entity pages or the IOC feed. Saves analysts reading nine versions of the same story.