### PR TITLE
Add threat intelligence resource: ScanMalware

### DIFF
--- a/threat_intelligence.md
+++ b/threat_intelligence.md
@@ -181,6 +181,7 @@ Here is [another example](https://www.infinigate.com/fr/vendors/sekoia/) of an a
   * URL/IP multi-search portal:
     * [CyberGordon](https://cybergordon.com/)
   * [URL analysis](https://urlscan.io/)
+  * ScanMalware, [free sandboxed URL analysis, with a public scan archive pivotable by domain, IP, ASN, JARM or favicon hash](https://scanmalware.com)
   * Data breaches search portals:
     * [Have I Been Pwned](https://haveibeenpwned.com/)
     * PCloud, [Free Personal Data Breach Checker](https://www.pcloud.com/fr/pass/free-personal-data-breach-checker.html)


### PR DESCRIPTION
Adds ScanMalware to the "Well-known OSINT portals/websites" list in `threat_intelligence.md`, directly after the urlscan.io entry, since it serves the same analyst workflow.

It renders a submitted URL in a sandboxed browser and returns a phishing/malware verdict alongside network requests, detected technologies, TLS/JARM fingerprints, YARA matches and a screenshot. What makes it useful past one-off detonation is the archive: 549,375 scans as of today, pivotable by domain, IP, ASN, JARM, favicon mmh3, TLSH/ssdeep fuzzy hash, screenshot hash and OCR text, so an IOC from an alert can be turned into related infrastructure rather than just a verdict.

Free, and no account is needed either to scan or to browse the feed. The REST API needs no authentication:

```
curl 'https://scanmalware.com/api/v1/recent?limit=1'
```

600 req/min anonymous, 3000 with a key. Docs at https://scanmalware.com/api-docs.

On formatting: I used the `Name, [description](url)` form the section already uses for the PCloud and Cisco entries, so the one-sentence description CONTRIBUTING asks for sits in the link text rather than as a separate line. Happy to switch to a plain `[ScanMalware](...)` bullet, or to move it elsewhere if you would rather it sat under a different heading.

Full disclosure: I run ScanMalware (Triop AB, Sweden). If you would prefer to evaluate and add it yourself, or not at all, say the word and I will close this.
