### PR TITLE
Add log analysis tool: sigwood (1.0.0)

### DIFF
--- a/mission-critical-means.md
+++ b/mission-critical-means.md
@@ -122,7 +122,7 @@ The provided recommendations are based on experience and search.
 * **Logs analyzers with detection capabilities**:
     * My recommendations:
       * Paid ones: [Sekoia Defend (XDR)](https://www.sekoia.com/platform/defend), 
-      * Community-provided / free ones: [Zircolite](https://github.com/wagga40/Zircolite), [DeepBlue](https://github.com/sans-blue-team/DeepBlueCLI), [CrowdSec](https://doc.crowdsec.net/docs/user_guides/replay_mode)
+      * Community-provided / free ones: [Zircolite](https://github.com/wagga40/Zircolite), [DeepBlue](https://github.com/sans-blue-team/DeepBlueCLI), [CrowdSec](https://doc.crowdsec.net/docs/user_guides/replay_mode), [sigwood](https://github.com/helixmap/sigwood): a local-first CLI that surfaces explainable hunting leads from Zeek, Pi-hole/dnsmasq, syslog and CloudTrail logs.
       
 # Other critical tools for a SOC and a CERT/CSIRT
 * **Secure secrets sharing**:


### PR DESCRIPTION
Hi, following up on #25 as agreed.

sigwood reached 1.0.0 and is published on PyPI. The CLI and the output formats are now frozen for the 1.x line, and the project publishes a compatibility contract covering the JSON and CSV outputs.

This re-files the same entry, rebased on current main. One change from the original: the description now says the tool surfaces hunting leads rather than "detects anomalous activity", which is a more accurate account of what it does.

Disclosure: I am the author of sigwood.

Thanks and regards,